### PR TITLE
Rename sliceFinish to sliceEnd to comply with event name change

### DIFF
--- a/src/useDCPWorker.tsx
+++ b/src/useDCPWorker.tsx
@@ -619,10 +619,10 @@ const useDCPWorker = ({
         };
 
         sandbox.on('start', onStart);
-        sandbox.on('sliceFinish', onFinish);
+        sandbox.on('sliceEnd', onFinish);
         sandbox.on('terminate', () => {
           sandbox.off('start', onStart);
-          sandbox.off('sliceFinish', onFinish);
+          sandbox.off('sliceEnd', onFinish);
         });
       });
       dcpWorker.on('submit', () => {


### PR DESCRIPTION
The worker event API has changed to meet new specifications. Update the worker hook to comply. 