### PR TITLE
build(npm): update min node version to 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=16",
+        "node": ">=18",
         "npm": ">=7"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "packageManager": "npm@9.6.7",
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=7"
   }
 }


### PR DESCRIPTION
To address the EOL for security updates of Node 16 on 2023-09-11.

Commands ran to update the `package*.json` files:

```console
npm pkg set engines.node='>=18'
npm install --package-lock-only
```

Refs: https://nodejs.dev/en/about/releases/