### PR TITLE
fix(worker events): update workingSandboxes on sandbox end

### DIFF
--- a/src/useDCPWorker.tsx
+++ b/src/useDCPWorker.tsx
@@ -605,6 +605,12 @@ const useDCPWorker = (
             data: measurements.elapsed, // seconds
           });
         });
+        sandbox.on('end', () => {
+          dispatchWorkerState({
+            type: WorkerStateActions.SET_WORKER_SBX,
+            data: dcpWorker.workingSandboxes.length,
+          });
+        });
       });
       dcpWorker.on('payment', (payment: number) => {
         dispatchWorkerStats({ type: WorkerStatsActions.ADD_SLICE });


### PR DESCRIPTION
When a worker is force terminated, the payment event is not fired for each slice, so workingSandboxes will never be updated.

This commit adds an event listener that updates workingSandboxes on sandbox end as it will always be fired on sandbox terminate.